### PR TITLE
Feature/update mat files to v7

### DIFF
--- a/openep_updateuserdata.m
+++ b/openep_updateuserdata.m
@@ -1,24 +1,29 @@
-function path = openep_updateuserdata(varargin)
-% OPENEP_UPDATEUSERDATA is used to make non-data related changes to
-% userdata
+function nU = openep_updateuserdata(f, varargin)
+% OPENEP_UPDATEUSERDATA is used to modify userdata
 %
 % Usage:
-%   path = openep_updateuserdata(userdata)
-%   path = openep_updateuserdata(dir)
-%   path = openep_updateuserdata(f)
+%   newUserData = openep_updateuserdata(dir, varargin)
 %
 % Where:
-%   userdata - openEP userdata structure
-%   dir      - path to a userdata .mat file or a directory containing multiple
-%              userdata .mat files
-%   path     - path to the new .mat file
+%   f      - path to a single userdata .mat file, or userdata
+%   nU     - the new userdata
 %
 % OPENEP_UPDATEUSERDATA accepts the following parameter-value pairs
-%   'version'     {'-v7.3'} | '-v7' | '-v6'
+%   'outputpath'    {[]} | <string>
+%   'version'       {'-v7.3'} | '-v7' | '-v6'
+%   'unpacktrirep'  {false} | true
 %
 % OPENEP_UPDATEUSERDATA is used to make non-data related changes to
 % userdata. The following interventions are possible
-% 1) By specifying 'version', the save version can be set (see help save)
+% 1) By specifying 'version', the save version can be modified (see help 
+%    save). Note that unless otherwise specified, '-v7.3' is used, and that
+%    saving to disc is optional.
+% 2) Convert userdata.surface.triRep to a structure rather than a triRep.
+%    This is useful for example if userdata is subsequently to be loaded
+%    into a non-Matlab environment
+% Note that this function handles single files only. Paths to single files 
+% are passed in as the argument, f. Userdata already loaded can also be
+% passed in as the argument, f. Limited error check is done on f.
 %
 % Author: Steven Williams (2021)
 % Modifications -
@@ -32,26 +37,58 @@ function path = openep_updateuserdata(varargin)
 % code
 % ---------------------------------------------------------------
 
-nStandardArgs = 2; % UPDATE VALUE
-value1 = 'NaN';
+nStandardArgs = 1; % UPDATE VALUE
+versionString = '-v7.3';
+unPackTriRep = false;
+outputPath = [];
 if nargin > nStandardArgs
     for i = 1:2:nargin-nStandardArgs
         switch varargin{i}
-            case 'param1'
-                value1 = varargin{i+1};
+            case 'version'
+                versionString = varargin{i+1};
+            case 'unpacktrirep'
+                unPackTriRep = varargin{i+1};
+            case 'outputpath'
+                outputPath = varargin{i+1};
         end
     end
 end
 
-if strcmpi(in1, 'openfile')
-    formatspec = {'*.vtk'};
-    instructionstring = 'Select a file';
-    [filename, pathname] = uiputfile(formatspec, instructionstring);
-    filePath = [pathname filename];
-else
-    filePath = in1;
+% Load or access the userdata
+try
+    if ischar(f)
+        if isfile(f)
+            load(f,'userdata');
+        end
+    elseif isstruct(f)
+        userdata = f;
+    else
+        error('OPENEP/OPENEP_UPDATEUSERDATA: Invalid input, no userdata found')
+    end
+catch
+    error('OPENEP/OPENEP_UPDATEUSERDATA: Invalid input, no userdata found')
 end
 
+% Unpack the TriRep (for example, for loading the .mat file into Python
+if unPackTriRep
+    X = userdata.surface.triRep.X;
+    Triangulation = userdata.surface.triRep.Triangulation;
+    userdata.surface.triRep = [];
+    userdata.surface.triRep.X = X;
+    userdata.surface.triRep.Triangulation = Triangulation;
+    
+    % Store comment about triRep
+    userdata.notes{end+1} = [date ': TriRep unpacked using openep_updateuserdata.m'];
+end
 
+if ~isempty(outputPath)
+    % Store comment about file format
+    userdata.notes{end+1} = [date ': Converted to ' '-v7.3' ' using openep_updateuserdata.m'];
+    save(outputPath, 'userdata', versionString);
+    disp(['OPENEP/OPENEP_UPDATEUSERDATA: Data saved to ' outputPath]);
+end
+
+% output the updated userdata to the calling environment
+nU = userdata;
 
 end

--- a/openep_updateuserdata.m
+++ b/openep_updateuserdata.m
@@ -1,0 +1,57 @@
+function path = openep_updateuserdata(varargin)
+% OPENEP_UPDATEUSERDATA is used to make non-data related changes to
+% userdata
+%
+% Usage:
+%   path = openep_updateuserdata(userdata)
+%   path = openep_updateuserdata(dir)
+%   path = openep_updateuserdata(f)
+%
+% Where:
+%   userdata - openEP userdata structure
+%   dir      - path to a userdata .mat file or a directory containing multiple
+%              userdata .mat files
+%   path     - path to the new .mat file
+%
+% OPENEP_UPDATEUSERDATA accepts the following parameter-value pairs
+%   'version'     {'-v7.3'} | '-v7' | '-v6'
+%
+% OPENEP_UPDATEUSERDATA is used to make non-data related changes to
+% userdata. The following interventions are possible
+% 1) By specifying 'version', the save version can be set (see help save)
+%
+% Author: Steven Williams (2021)
+% Modifications -
+%
+% Info on Code Testing:
+% ---------------------------------------------------------------
+% test code
+% ---------------------------------------------------------------
+%
+% ---------------------------------------------------------------
+% code
+% ---------------------------------------------------------------
+
+nStandardArgs = 2; % UPDATE VALUE
+value1 = 'NaN';
+if nargin > nStandardArgs
+    for i = 1:2:nargin-nStandardArgs
+        switch varargin{i}
+            case 'param1'
+                value1 = varargin{i+1};
+        end
+    end
+end
+
+if strcmpi(in1, 'openfile')
+    formatspec = {'*.vtk'};
+    instructionstring = 'Select a file';
+    [filename, pathname] = uiputfile(formatspec, instructionstring);
+    filePath = [pathname filename];
+else
+    filePath = in1;
+end
+
+
+
+end


### PR DESCRIPTION
Hi Nick,

This feature does a couple of things
(1) function to read and re-save older .mat files into the -v7.3 format
(2) option to unpack userdata.structure.triRep into .X / .Triangulation structure because it is not possible to read a TriRep object into Python.

I'm just making a pull request for this into 'develop'; it can be a feature that is added to the next OpenEP release on 'master'.

Steven