### PR TITLE
Make calls to 'getMesh' use 'limitToTriangulation' rather than 'repack'

### DIFF
--- a/HoleCutter.m
+++ b/HoleCutter.m
@@ -51,8 +51,6 @@ classdef HoleCutter < matlab.mixin.SetGet
         end
         
         function initialiseGeodesicCalculation(obj)
-            % Initialise the geodesic library and algorithm
-            initialiseGeodesic()
             mesh = geodesic_new_mesh(obj.Mesh.Points, obj.Mesh.ConnectivityList);
             obj.Algorithm = geodesic_new_algorithm(mesh, 'exact');
         end

--- a/cutMesh.m
+++ b/cutMesh.m
@@ -39,7 +39,7 @@ disp('Select points on the mesh and press any key when done')
 pause;
 
 % perform mesh cutting
-hc = HoleCutter(getMesh(userdata, 'type', 'triangulation', 'repack', true), hT);
+hc = HoleCutter(getMesh(userdata, 'type', 'triangulation', 'limitToTriangulation', true), hT);
 
 disp('hc.computeCutOut')
 hc.computeCutOut

--- a/distanceBetweenPoints.m
+++ b/distanceBetweenPoints.m
@@ -77,9 +77,15 @@ switch method
         
         % calculate the geodesic distance (repacking and reducepatch
         % necessary to prevent ?memory problem in exact geodesic)
-        V = userdata.surface.triRep.X;
-        F = userdata.surface.triRep.Triangulation;
-        [faces,vertices] = reducepatch(F,V,size(F,1));
+        %V = userdata.surface.triRep.X;
+        %F = userdata.surface.triRep.Triangulation;
+        %[faces,vertices] = reducepatch(F,V,size(F,1));
+        
+        % calculate the geodesic distance (repacking to remove points
+        % not referenced in the triangulation)
+        tr = getMesh(userdata, 'limitToTriangulation', true);
+        vertices = tr.X;
+        faces = tr.Triangulation;
         
         % now find the closest vertex index to A and B
         P1new = findclosestvertex(vertices, A);

--- a/distanceBetweenPoints.m
+++ b/distanceBetweenPoints.m
@@ -32,9 +32,6 @@ function distance = distanceBetweenPoints(userdata, P1, P2, varargin)
 % code
 % ---------------------------------------------------------------
 
-% Initialise the geodesic library and algorithm
-initialiseGeodesic()
-
 % parse input arguments
 nStandardArgs = 3;
 method = 'linear';
@@ -74,12 +71,6 @@ switch method
         % get the co-ordinates of the surface points
         A = userdata.electric.egmSurfX(P1,:);
         B = userdata.electric.egmSurfX(P2,:);
-        
-        % calculate the geodesic distance (repacking and reducepatch
-        % necessary to prevent ?memory problem in exact geodesic)
-        %V = userdata.surface.triRep.X;
-        %F = userdata.surface.triRep.Triangulation;
-        %[faces,vertices] = reducepatch(F,V,size(F,1));
         
         % calculate the geodesic distance (repacking to remove points
         % not referenced in the triangulation)

--- a/generateInterpData.m
+++ b/generateInterpData.m
@@ -159,7 +159,7 @@ for i = 1:size(data,2)
     
     % Remove any data which is associated with vertices that are not 
     % referenced by the triangulation
-    [~,isVertUsed] = repack(userdata.surface.triRep);
+    [~,isVertUsed] = repack(getMesh(userdata.surface.triRep));
     interpData(~isVertUsed,i) = NaN;
 end
 

--- a/getAllAttachedMesh.m
+++ b/getAllAttachedMesh.m
@@ -39,7 +39,7 @@ pause;
 % Get the co-ordinate of the point and the vertex index
 dataTip = get(hT, 'children');
 XYZ(1,1:3) = [dataTip(1).X dataTip(1).Y dataTip(1).Z];
-trSurface = getMesh(userdata, 'type', 'triangulation', 'repack', true)
+trSurface = getMesh(userdata, 'type', 'triangulation', 'limitToTriangulation', true)
 iV(1) = findclosestvertex(trSurface, XYZ(1,:));
 
 % Get all the attached surface

--- a/getMesh.m
+++ b/getMesh.m
@@ -50,7 +50,7 @@ if nargin > nStandardArgs
     end
 end
 if ~any(strcmpi({'trirep' 'triangulation' 'struct'}, type))
-    error(['OPENEP/GETMESH: Value: ' type ' for parameter: type not recognised']);
+    error('OPENEP:invalidArgument', ['OPENEP/GETMESH: Value: ' type ' for parameter: type not recognised']);
 end
 
 % Check the type of surface data stored in the OpenEP datastructure and
@@ -63,13 +63,15 @@ elseif isa(userdata.surface.triRep, 'triangulation')
     FV.faces = userdata.surface.triRep.ConnectivityList;
 elseif isa(userdata.surface.triRep, 'struct')
     if ~isfield(userdata.surface.triRep, 'X')
-        error('OPENEP/GETMESH: invalid data. userdata.surface.triRep must be one of: TriRep, triangulation or struct with fields .X and .Triangulation');
+        error('OPENEP:invalidData', 'OPENEP/GETMESH: invalid data. userdata.surface.triRep must be one of: TriRep, triangulation or struct with fields .X and .Triangulation');
     end
     if ~isfield(userdata.surface.triRep, 'Triangulation')
-        error('OPENEP/SETMESH: invalid data. userdata.surface.triRep must be one of: TriRep, triangulation or struct with fields .X and .Triangulation');
+        error('OPENEP:invalidData', 'OPENEP/GETMESH: invalid data. userdata.surface.triRep must be one of: TriRep, triangulation or struct with fields .X and .Triangulation');
     end
     FV.vert = userdata.surface.triRep.X;
     FV.faces = userdata.surface.triRep.Triangulation;
+else
+    error('OPENEP:invalidData', 'OPENEP/GETMESH: userdata.surface.triRep must be one of: TriRep, triangulation or struct');
 end
 
 switch lower(type)

--- a/getMesh.m
+++ b/getMesh.m
@@ -90,7 +90,7 @@ switch lower(type)
             tr = userdata.surface.triRep;
         else
             tr.X = FV.vert;
-            tr.Points = FV.faces;
+            tr.Triangulation = FV.faces;
         end
 end
 

--- a/getMesh.m
+++ b/getMesh.m
@@ -34,7 +34,6 @@ function tr = getMesh(userdata, varargin)
 nStandardArgs = 1; % UPDATE VALUE
 type = 'trirep';
 limitToTriangulation = false;
-dorepack = false;
 
 if nargin > nStandardArgs
     for i = 1:2:nargin-nStandardArgs
@@ -44,7 +43,9 @@ if nargin > nStandardArgs
             case 'limittotriangulation'
                 limitToTriangulation = varargin{i+1};
             case 'repack'
-                dorepack = varargin{i+1};
+                warning("OPENEP:deprecation", "The 'repack' argument is " + ...
+                    "deprecated. Please use 'limitToTriangulation instead.'")
+                limitToTriangulation = varargin{i+1};
         end
     end
 end

--- a/private/geodesic_delete.m
+++ b/private/geodesic_delete.m
@@ -4,6 +4,15 @@
 function object = geodesic_delete(object)
 
 global geodesic_library;
+
+if ismac
+    geodesic_library = 'geodesic_matlab_api_macos';
+elseif isunix
+    geodesic_library = 'geodesic_matlab_api';
+else
+    disp('Platform not supported')
+end
+
 if ~libisloaded(geodesic_library)       %everything is already cleared
     object = [];
     return;

--- a/private/geodesic_new_mesh.m
+++ b/private/geodesic_new_mesh.m
@@ -1,16 +1,7 @@
 function [mesh, edge_to_vertex, edge_to_face] = geodesic_new_mesh(points, tri)
 
-global geodesic_library
-if ~libisloaded(geodesic_library)
-    hfile = 'geodesic_matlab_api.h';
-    if ispc
-        loadlibrary([geodesic_library '.dll'], hfile);
-    elseif isunix
-        loadlibrary([geodesic_library '.so'], hfile);
-    else
-        disp('Platform not supported')
-    end
-end
+global geodesic_library;
+initialiseGeodesic();
 
 dim = find(size(points) == 3);
 if dim == 1

--- a/private/repack.m
+++ b/private/repack.m
@@ -20,6 +20,9 @@ function [tNew, isVertUsed] = repack(t)
     elseif isa(t,'triangulation')
         tri = t.ConnectivityList;
         x = t.Points;
+    elseif isa(t, 'struct')
+        tri = t.Triangulation;
+        x = t.X;
     else
         error('REPACK: wrong type of input.')
     end
@@ -39,6 +42,9 @@ function [tNew, isVertUsed] = repack(t)
         tNew = TriRep(newTri, newX); %#ok<DTRIREP>
     elseif isa(t,'triangulation')
         tNew = triangulation(newTri, newX);
+    elseif isa(t, 'struct')
+        tNew.X = newX;
+        tNew.Triangulation = newTri;
     end
 
 

--- a/tests/getMeshTest.m
+++ b/tests/getMeshTest.m
@@ -51,6 +51,48 @@ classdef getMeshTest < matlab.unittest.TestCase
 
         end
 
+        function triangulationInput(testCase, type, limitToTriangulation)
+
+            testCase.userdata.surface.triRep = testCase.triangulation_surface;
+            [limit, expected_num_vertices, expected_num_faces] = limitToTriangulation{:};
+
+            tr = getMesh( ...
+                testCase.userdata, ...
+                'type', type, ...
+                'limitToTriangulation', limit);
+
+            switch type
+                case 'triangulation'
+                    testCase.verifyEqual(length(tr.Points), expected_num_vertices);
+                    testCase.verifyEqual(length(tr.ConnectivityList), expected_num_faces);
+                otherwise
+                    testCase.verifyEqual(length(tr.X), expected_num_vertices);
+                    testCase.verifyEqual(length(tr.Triangulation), expected_num_faces);
+            end
+
+        end
+
+        function structInput(testCase, type, limitToTriangulation)
+
+            testCase.userdata.surface.triRep = testCase.struct_surface;
+            [limit, expected_num_vertices, expected_num_faces] = limitToTriangulation{:};
+
+            tr = getMesh( ...
+                testCase.userdata, ...
+                'type', type, ...
+                'limitToTriangulation', limit);
+
+            switch type
+                case 'triangulation'
+                    testCase.verifyEqual(length(tr.Points), expected_num_vertices);
+                    testCase.verifyEqual(length(tr.ConnectivityList), expected_num_faces);
+                otherwise
+                    testCase.verifyEqual(length(tr.X), expected_num_vertices);
+                    testCase.verifyEqual(length(tr.Triangulation), expected_num_faces);
+            end
+
+        end
+
     end
 
 end

--- a/tests/getMeshTest.m
+++ b/tests/getMeshTest.m
@@ -1,0 +1,56 @@
+classdef getMeshTest < matlab.unittest.TestCase
+
+    properties(TestParameter)
+        type = {'trirep'; 'triangulation'; 'struct'};
+        limitToTriangulation = {{true, 5432, 10296}; {false, 9279, 10296}};
+    end
+
+    properties
+        userdata;
+        triRep_surface;
+        triangulation_surface;
+        struct_surface;
+    end
+
+    methods(TestClassSetup)
+        function loadData(testCase)
+
+            testCase.userdata = load('openep_dataset_1.mat').userdata;
+
+            vertices = testCase.userdata.surface.triRep.X;
+            faces = testCase.userdata.surface.triRep.Triangulation;
+            
+            testCase.triRep_surface = TriRep(faces, vertices(:,1), vertices(:,2), vertices(:,3));
+            testCase.triangulation_surface = triangulation(faces, vertices);
+            testCase.struct_surface.X = vertices;
+            testCase.struct_surface.Triangulation = faces;
+
+        end
+    end
+
+    methods(Test, ParameterCombination = 'pairwise')
+
+        function triRepInput(testCase, type, limitToTriangulation)
+
+            testCase.userdata.surface.triRep = testCase.triRep_surface;
+            [limit, expected_num_vertices, expected_num_faces] = limitToTriangulation{:};
+
+            tr = getMesh( ...
+                testCase.userdata, ...
+                'type', type, ...
+                'limitToTriangulation', limit);
+
+            switch type
+                case 'triangulation'
+                    testCase.verifyEqual(length(tr.Points), expected_num_vertices);
+                    testCase.verifyEqual(length(tr.ConnectivityList), expected_num_faces);
+                otherwise
+                    testCase.verifyEqual(length(tr.X), expected_num_vertices);
+                    testCase.verifyEqual(length(tr.Triangulation), expected_num_faces);
+            end
+
+        end
+
+    end
+
+end

--- a/tests/getMeshTest.m
+++ b/tests/getMeshTest.m
@@ -95,4 +95,61 @@ classdef getMeshTest < matlab.unittest.TestCase
 
     end
 
+    methods(Test)
+
+        function repackArgumentDeprecated(testCase)
+            
+            verifyWarning( ...
+                testCase, ...
+                @() getMesh(testCase.userdata, 'repack', 'true'), ...
+                "OPENEP:deprecation");
+
+        end
+
+        function invalidArgument(testCase)
+            
+            verifyError( ...
+                testCase, ...
+                @() getMesh(testCase.userdata, 'type', 'invalidType'), ...
+                "OPENEP:invalidArgument");
+
+        end
+
+        function missingVertices(testCase)
+
+            testCase.userdata.surface.triRep = testCase.struct_surface;
+            testCase.userdata.surface.triRep = rmfield(testCase.userdata.surface.triRep, 'X');
+
+            verifyError(...
+                testCase, ...
+                @() getMesh(testCase.userdata), ...
+                "OPENEP:invalidData");
+
+        end 
+
+        function missingFaces(testCase)
+
+            testCase.userdata.surface.triRep = testCase.struct_surface;
+            testCase.userdata.surface.triRep = rmfield(testCase.userdata.surface.triRep, 'Triangulation');
+
+            verifyError(...
+                testCase, ...
+                @() getMesh(testCase.userdata), ...
+                "OPENEP:invalidData");
+
+        end 
+
+        function invalidData(testCase)
+
+            testCase.userdata.surface.triRep =  "Bad input type";
+
+            verifyError(...
+                testCase, ...
+                @() getMesh(testCase.userdata), ...
+                "OPENEP:invalidData");
+        
+        end
+
+    end
+
 end


### PR DESCRIPTION
Fixes #59
Note, this PR does NOT fix #55 

Changes made:
* Emit a warning if the `repack` argument is passed to `getMesh`
* The new `limitToTriangulation` argument of `getMesh` is used instead of `repack` in the following files:
  -  `distanceBetweenPoints`
  - `getAllAttachedMesh`
  - `cutMesh`
* `distanceBetweenPoints` now uses `getMesh` with `limitToTriangulation` set to `true`, instead of calling `reducepatch`. This is because `reducepatch` also reduces the resolution of the mesh, which is not necessary here.
* `initialiseGeodesic` is called in `private/geodesic_new_mesh`, rather than in `distanceBetweenPoints` or `HoleCutter`
* in `getMesh`, if `type` is `struct`, store the face data in `tr.Triangulation` rather than `tr.Points`
* in `generateInterpData`, call `getMesh` before repacking