### PR TITLE
fixed error in opeep2vtk.m

### DIFF
--- a/openEP2VTK.m
+++ b/openEP2VTK.m
@@ -53,7 +53,7 @@ if nargin > nStandardArgs
             case 'method'
                 method = varargin{i+1};
             case 'outputfile'
-                method = varargin{i+1};
+                outputfile = varargin{i+1};
         end
     end
 end


### PR DESCRIPTION
Fixes #68 

* Correctly set output filename (previously the filename was assigned to `method`)