### PR TITLE
Fixing ambiguous match bug in importcarto_mem.m

### DIFF
--- a/importcarto_mem.m
+++ b/importcarto_mem.m
@@ -746,7 +746,7 @@ for iMap = selection
 
     % Encourage user to save the data
     if ~isempty(saveFileName_cli)
-        save(saveFileName_cli, 'userdata');
+        save(saveFileName_cli, 'userdata', '-v7.3'); %needed as sometimes >2GB
         matFileFullPath = saveFileName_cli;
     else
         defaultName = [map.studyName '_' map.name];

--- a/importcarto_mem.m
+++ b/importcarto_mem.m
@@ -221,7 +221,7 @@ else
                 ' points identified. Check the number of points specified is correct.']);
         end
     elseif ischar(mapToRead_cli)
-        selection = find(strstartcmpi(mapToRead_cli, names));
+        selection = find(strcmpi(mapToRead_cli, names));
     end
 end
 


### PR DESCRIPTION
This pull request updates `importcarto_mem.m` in two places. 

First, it changes the map-name matching logic to use exact, case-insensitive string matching when identifying the selected Carto map.
Previously, map names were matched using `strstartcmpi`, which could return multiple matches when another map name started with the same characters as the selected map. For example, if a study contained maps named "2-LA" and "2-LA something", selecting "2-LA" would match both entries.
This would cause the following error at line 241 `map.name = cartoMap.ATTRIBUTE.Name;`:
```matlab
Intermediate dot '.' indexing produced a comma-separated list with 2 values, but it must produce a single value when followed by subsequent indexing operations.
```
The change replaces `strstartcmpi` with `strcmpi`, ensuring that only exact map-name matches are returned while preserving case-insensitive comparison. This keeps the behavior consistent with the intended single-match logic in lines 214-217.

Second, it updates the `save` call at line 749 has been updated to use the -v7.3 MAT-file format, as in line 760.